### PR TITLE
Remove --babelrc, making Babel use non-archetype config

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Tasks:
     [builder-react-component] webpack --config node_modules/builder-react-component/config/webpack/webpack.config.js
 
   build-lib
-    [builder-react-component] builder run clean-lib && babel --babelrc node_modules/builder-react-component/config/babel/.babelrc src -d lib
+    [builder-react-component] builder run clean-lib && babel src -d lib
 
   check
     [builder-react-component] builder run lint && builder run test

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ and the exported class name is `MyCoolComponent`.
 An example project using this structure is:
 [formidable-react-component-boilerplate][]
 
+## Usage Notes
+
+This archetype does not currently specify its own `.babelrc`. Your project
+should specify its own in the root directory if you want non-default Babel
+settings (like using stage 0, for instance). See [the recommended
+settings](config/babel/.babelrc).
+
 ## Tasks
 
 ```

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-dist-dev": "webpack --config node_modules/builder-react-component/config/webpack/webpack.config.dev.js --colors",
     "build-dist": "builder run clean-dist && builder run build-dist-min && builder run build-dist-dev",
     "clean-lib": "rimraf lib",
-    "build-lib": "builder run clean-lib && babel --babelrc node_modules/builder-react-component/config/babel/.babelrc src -d lib",
+    "build-lib": "builder run clean-lib && babel src -d lib",
     "clean": "builder run clean-lib && builder run clean-dist",
     "build": "builder run build-lib && builder run build-dist",
     "server-dev": "webpack-dev-server --port 3000 --config node_modules/builder-react-component/config/webpack/demo/webpack.config.dev.js --colors --content-base demo",


### PR DESCRIPTION
This removes `--babelrc` and will require boilerplates and other projects using this archetype to add their own `.babelrc` if they want non-default settings.

This PR does not remove the actual `.babelrc` file in this repo – it's not hurting anything, can be used as a reference, and will most likely be used again later when specifying a custom babelrc is more widely supported.

Reference: #4 (we should leave that issue open until this is actually resolved)

/cc @boygirl @ryan-roemer
