### PR TITLE
bump eslint to non-breaking version

### DIFF
--- a/dev/package.json
+++ b/dev/package.json
@@ -15,7 +15,7 @@
   "scripts": {},
   "dependencies": {
     "babel-eslint": "^4.1.3",
-    "eslint": "^1.7.3",
+    "eslint": "^1.10.1",
     "eslint-config-defaults": "^7.0.1",
     "eslint-plugin-filenames": "^0.1.2",
     "eslint-plugin-react": "^3.6.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "webpack": "^1.11.0"
   },
   "devDependencies": {
-    "eslint": "^1.7.3",
+    "eslint": "^1.10.1",
     "eslint-config-defaults": "^7.0.1",
     "eslint-plugin-filenames": "^0.1.2"
   }


### PR DESCRIPTION
cc/ @ryan-roemer 

We had an issue with `eslint@1.10.0`, this bumps the version to `^1.10.1` to avoid the broken version. 
