### PR TITLE
Add `builder-init` template support.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,204 @@
+Development
+===========
+
+We use [builder][] and `npm` to control all aspects of development and
+publishing.
+
+As a preliminary matter, please update your shell to include
+`./node_modules/.bin` in `PATH` like:
+
+```sh
+export PATH="${PATH}:./node_modules/.bin"
+```
+
+So you can type `builder` instead of `./node_modules/.bin/builder` for all
+commands.
+
+
+## Build
+
+Build for production use (NPM, bower, etc) and create `dist` UMD bundles
+(min'ed, non-min'ed)
+
+```
+$ builder run build
+```
+
+Note that `dist/` files are only updated and committed on **tagged releases**.
+
+
+## Development
+
+All development tasks consist of watching the demo bundle, the test bundle
+and launching a browser pointed to the demo page.
+
+Run the `demo` application with watched rebuilds either doing:
+
+### Basic Watched Builds
+
+```sh
+$ builder run dev       # dev test/app server
+$ builder run open-dev  # (OR) dev servers _and a browser window opens!_
+```
+
+### Watched Builds + Hot Reloading
+
+Same as above, but with hot reloading of React components.
+
+```sh
+$ builder run hot       # hot test/app server
+$ builder run open-hot  # (OR) hot servers _and a browser window opens!_
+```
+
+From there, using either `dev` or `hot`, you can see:
+
+* Demo app: [127.0.0.1:3000](http://127.0.0.1:3000/)
+* Client tests: [127.0.0.1:3001/test/client/test.html](http://127.0.0.1:3001/test/client/test.html)
+
+
+## Programming Guide
+
+### Logging
+
+We use the following basic pattern for logging:
+
+```js
+if (process.env.NODE_ENV !== "production") {
+  /* eslint-disable no-console */
+  if (typeof console !== "undefined" && console.warn) {
+    console.warn("Oh noes! bad things happened.");
+  }
+  /* eslint-enable no-console */
+}
+```
+
+Replace `console.warn` in the condtional + method call as appropriate.
+
+Breaking this down:
+
+* `process.env.NODE_ENV !== "production"` - This part removes all traces of
+  the code in the production bundle, to save on file size. This _also_ means
+  that no warnings will be displayed in production.
+* `typeof console !== "undefined" && console.METHOD` - A permissive check to
+  make sure the `console` object exists and can use the appropriate `METHOD` -
+  `warn`, `info`, etc.
+
+To signal production mode to the webpack build, declare the `NODE_ENV` variable:
+
+```js
+new webpack.DefinePlugin({
+  "process.env.NODE_ENV": JSON.stringify("production")
+})
+```
+
+Unfortunately, we need to do _all_ of this every time to have Uglify properly
+drop the code, but with this trick, the production bundle has no change in code
+size.
+
+
+## Quality
+
+### In Development
+
+During development, you are expected to be running either:
+
+```sh
+$ builder run dev
+```
+
+to build the lib and test files. With these running, you can run the faster
+
+```sh
+$ builder run check-dev
+```
+
+Command. It is comprised of:
+
+```sh
+$ builder run lint
+$ builder run test-dev
+```
+
+Note that the tests here are not instrumented for code coverage and are thus
+more development / debugging friendly.
+
+### Continuous Integration
+
+CI doesn't have source / test file watchers, so has to _build_ the test files
+via the commands:
+
+```sh
+$ builder run check     # PhantomJS only
+$ builder run check-cov # (OR) PhantomJS w/ coverage
+$ builder run check-ci  # (OR) PhantomJS,Firefox + coverage - available on Travis.
+```
+
+Which is currently comprised of:
+
+```sh
+$ builder run lint  # AND ...
+
+$ builder run test      # PhantomJS only
+$ builder run test-cov  # (OR) PhantomJS w/ coverage
+$ builder run test-ci   # (OR) PhantomJS,Firefox + coverage
+```
+
+Note that `(test|check)-(cov|ci)` run code coverage and thus the
+test code may be harder to debug because it is instrumented.
+
+### Client Tests
+
+The client tests rely on webpack dev server to create and serve the bundle
+of the app/test code at: http://127.0.0.1:3001/assets/main.js which is done
+with the task `builder run server-test` (part of `npm dev`).
+
+#### Code Coverage
+
+Code coverage reports are outputted to:
+
+```
+coverage/
+  client/
+    BROWSER_STRING/
+      lcov-report/index.html  # Viewable web report.
+```
+
+## Releases
+
+**IMPORTANT - NPM**: To correctly run `preversion` your first step is to make
+sure that you have a very modern `npm` binary:
+
+```sh
+$ npm install -g npm
+```
+
+Built files in `dist/` should **not** be committeed during development or PRs.
+Instead we _only_ build and commit them for published, tagged releases. So
+the basic workflow is:
+
+```sh
+# Make sure you have a clean, up-to-date `master`
+$ git pull
+$ git status # (should be no changes)
+
+# Choose a semantic update for the new version.
+# If you're unsure, read about semantic versioning at http://semver.org/
+$ npm version major|minor|patch -m "Version %s - INSERT_REASONS"
+
+# ... the `dist/` and `lib/` directories are now built, `package.json` is
+# updated, and the appropriate files are committed to git (but unpushed).
+#
+# *Note*: `lib/` is uncommitted, but built and must be present to push to npm.
+
+# Check that everything looks good in last commit and push.
+$ git diff HEAD^ HEAD
+$ git push && git push --tags
+# ... the project is now pushed to GitHub and available to `bower`.
+
+# And finally publish to `npm`!
+$ npm publish
+```
+
+And you've published!
+
+[builder]: https://github.com/FormidableLabs/builder

--- a/README.md
+++ b/README.md
@@ -15,9 +15,28 @@ $ npm install --save builder-react-component
 $ npm install --save-dev builder-react-component-dev
 ```
 
+## Generator
+
+> **NOTE**: `builder-init` support is **not yet implemented**.
+> https://github.com/FormidableLabs/builder-init/issues/2
+
+To bootstrap a new project from scratch with template files from this
+archetype, you can use [builder-init][]:
+
+```sh
+$ npm install -g builder-init
+$ builder-init builder-react-component
+```
+
+This will download this archetype, prompt you for several template data values
+and inflate the [archetype templates](./init) to real files at a chosen
+directory.
+
 ## Project Structure
 
-This archetype assumes an architecture as follows:
+See the [development][] guide for workflows associated with this archetype.
+
+The archetype assumes a file structure like the following:
 
 ```
 demo/
@@ -38,6 +57,11 @@ test
 .builderrc
 package.json
 ```
+
+This matches the [`builder-init` templates](init) found in the source of this
+archetype.
+
+### File / Component Name
 
 The `name` field in `package.json` (the published `npm` package name) is
 assumed to be:
@@ -63,9 +87,6 @@ dist/my-cool-component.min.js.map
 ```
 
 and the exported class name is `MyCoolComponent`.
-
-An example project using this structure is:
-[formidable-react-component-boilerplate][]
 
 ## Usage Notes
 
@@ -203,6 +224,7 @@ Tasks:
 ```
 
 [builder]: https://github.com/FormidableLabs/builder
-[formidable-react-component-boilerplate]: https://github.com/FormidableLabs/formidable-react-component-boilerplate
+[builder-init]: https://github.com/FormidableLabs/builder-init
+[development]: ./DEVELOPMENT.md
 [trav_img]: https://api.travis-ci.org/FormidableLabs/builder-react-component.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/builder-react-component

--- a/dev/README.md
+++ b/dev/README.md
@@ -15,9 +15,28 @@ $ npm install --save builder-react-component
 $ npm install --save-dev builder-react-component-dev
 ```
 
+## Generator
+
+> **NOTE**: `builder-init` support is **not yet implemented**.
+> https://github.com/FormidableLabs/builder-init/issues/2
+
+To bootstrap a new project from scratch with template files from this
+archetype, you can use [builder-init][]:
+
+```sh
+$ npm install -g builder-init
+$ builder-init builder-react-component
+```
+
+This will download this archetype, prompt you for several template data values
+and inflate the [archetype templates](./init) to real files at a chosen
+directory.
+
 ## Project Structure
 
-This archetype assumes an architecture as follows:
+See the [development][] guide for workflows associated with this archetype.
+
+The archetype assumes a file structure like the following:
 
 ```
 demo/
@@ -38,6 +57,11 @@ test
 .builderrc
 package.json
 ```
+
+This matches the [`builder-init` templates](init) found in the source of this
+archetype.
+
+### File / Component Name
 
 The `name` field in `package.json` (the published `npm` package name) is
 assumed to be:
@@ -63,9 +87,6 @@ dist/my-cool-component.min.js.map
 ```
 
 and the exported class name is `MyCoolComponent`.
-
-An example project using this structure is:
-[formidable-react-component-boilerplate][]
 
 ## Usage Notes
 
@@ -203,6 +224,7 @@ Tasks:
 ```
 
 [builder]: https://github.com/FormidableLabs/builder
-[formidable-react-component-boilerplate]: https://github.com/FormidableLabs/formidable-react-component-boilerplate
+[builder-init]: https://github.com/FormidableLabs/builder-init
+[development]: ./DEVELOPMENT.md
 [trav_img]: https://api.travis-ci.org/FormidableLabs/builder-react-component.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/builder-react-component

--- a/init.js
+++ b/init.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/**
+ * Archetype `init` configuration.
+ */
+// TODO: REMOVE AND IMPLEMENT PROMPTS
+// https://github.com/FormidableLabs/builder-init/issues/3
+/*eslint-disable no-console*/
+console.log("TODO HERE init.js");
+/*eslint-enable no-console*/

--- a/init/.babelrc
+++ b/init/.babelrc
@@ -1,0 +1,4 @@
+{
+  "stage": 0,
+  "nonStandard": true
+}

--- a/init/.builderrc
+++ b/init/.builderrc
@@ -1,0 +1,3 @@
+---
+archetypes:
+  - builder-react-component

--- a/init/.editorconfig
+++ b/init/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100
+
+[*.md]
+trim_trailing_whitespace = false

--- a/init/.gitignore
+++ b/init/.gitignore
@@ -1,0 +1,21 @@
+# Cruft
+*.sublime-workspace
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+.tmp
+npm-debug.log*
+
+# Code / build
+coverage
+node_modules
+bower_components
+lib

--- a/init/.npmignore
+++ b/init/.npmignore
@@ -1,0 +1,27 @@
+# Cruft
+*.sublime-workspace
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+.tmp
+npm-debug.log*
+
+# Code / build
+coverage
+node_modules
+bower_components
+demo
+test
+karma*
+webpack*
+.eslint*
+.editor*
+.travis*

--- a/init/.travis.yml
+++ b/init/.travis.yml
@@ -1,0 +1,35 @@
+language: node_js
+
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4.2"
+  - "5.0"
+
+# Use container-based Travis infrastructure.
+sudo: false
+
+branches:
+  only:
+    - master
+
+env:
+  matrix:
+    - NPM_3=true
+    - NPM_3=false
+
+before_install:
+  # GUI for real browsers.
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+  # Potentially update to npm 3
+  - 'if [ "$NPM_3" = true ]; then npm install -g npm@3; else true; fi'
+
+script:
+  - npm --version
+  - node_modules/.bin/builder run check-ci
+
+  # Prune deps to just production and ensure we can still build
+  - npm prune --production
+  - node_modules/.bin/builder run build

--- a/init/CONTRIBUTING.md
+++ b/init/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+Contributing
+============
+
+Thanks for helping out!
+
+## Development
+
+Run `builder run open-hot` or `builder run open-dev` to run a webpack dev server
+with component examples.
+
+## Checks, Tests
+
+Run `builder run check` before committing.
+
+## Dist
+
+Please do not commit changes to files in `dist`.
+These files are only committed when we tag releases.

--- a/init/LICENSE.txt
+++ b/init/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) <%= licenseDate %> <%= licenseOrg %>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/init/README.md
+++ b/init/README.md
@@ -1,0 +1,24 @@
+[![Travis Status][trav_img]][trav_site]
+
+# <%= packageName %>
+
+<%= packageDescription %>
+
+## Development
+
+All development tasks and common workflows can be found in the
+[builder-react-component][] archetype [development guide][arch-dev].
+
+This component was originally generated with [builder-init][], and uses
+[builder][] to support the entire development / release lifecycle.
+
+## Contributing
+
+Please see [CONTRIBUTING](CONTRIBUTING.md)
+
+[trav_img]: https://api.travis-ci.org/<%= packageGitHubOrg %>/<%= packageName %>.svg
+[trav_site]: https://travis-ci.org/<%= packageGitHubOrg %>/<%= packageName %>
+[builder]: https://github.com/FormidableLabs/builder
+[builder-init]: https://github.com/FormidableLabs/builder-init
+[builder-react-component]: https://github.com/FormidableLabs/builder-react-component
+[arch-dev]: https://github.com/FormidableLabs/builder-react-component/blob/master/DEVELOPMENT.md

--- a/init/demo/app.jsx
+++ b/init/demo/app.jsx
@@ -1,0 +1,18 @@
+/*global document:false*/
+import React from "react";
+import ReactDOM from "react-dom";
+import {<%= componentName %>} from "../src/index";
+
+class App extends React.Component {
+  render() {
+    return (
+      <div className="demo">
+        <<%= componentName %> />
+      </div>
+    );
+  }
+}
+
+const content = document.getElementById("content");
+
+ReactDOM.render(<App/>, content);

--- a/init/demo/index.html
+++ b/init/demo/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+<head>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.js"></script>
+  <![endif]-->
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>Demo</title>
+  <meta name="description" content="">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <style type="text/css">
+    * {
+      box-sizing: border-box;
+    }
+    .tile {
+      display: block;
+      float: left;
+      width: 100px;
+      height: 100px;
+      margin: 20px;
+    }
+    .tile img {
+      display: block;
+      width: 100px;
+      height: 100px;
+    }
+    .demo {
+      width: 80%;
+      margin: auto;
+      position: relative;
+    }
+  </style>
+</head>
+<body>
+  <!--[if lt IE 8]>
+    <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+  <![endif]-->
+  <div id="content"></div>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.1.15/es5-shim.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/4.1.15/es5-sham.min.js"></script>
+  <![endif]-->
+  <script src="http://localhost:3000/webpack-dev-server.js"></script>
+  <script src="assets/main.js"></script>
+  <script>
+    // Sanity-check the component loaded...
+    setTimeout(function () {
+      var content = document.querySelector("#content");
+      content.innerHTML = content.innerHTML ||
+        "If you can see this, something is broken (or JS is not enabled)!";
+    }, 500);
+  </script>
+</body>
+</html>

--- a/init/package.json
+++ b/init/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "<%= packageName %>",
+  "version": "0.0.1",
+  "description": "<%= packageDescription %>",
+  "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/<%= packageGitHubOrg %>/<%= packageName %>.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/<%= packageGitHubOrg %>/<%= packageName %>/issues"
+  },
+  "homepage": "https://github.com/<%= packageGitHubOrg %>/<%= packageName %>",
+  "scripts": {
+    "postinstall": "builder run npm:postinstall",
+    "preversion": "builder run npm:preversion",
+    "version": "builder run npm:version",
+    "test": "builder run npm:test"
+  },
+  "dependencies": {
+    "builder": "~2.2.0",
+    "builder-react-component": "^0.1.2"
+  },
+  "devDependencies": {
+    "builder-react-component-dev": "^0.1.2",
+    "chai": "^3.2.0",
+    "mocha": "^2.3.3",
+    "react": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0"
+  }
+}

--- a/init/src/components/{{componentPath}}.jsx
+++ b/init/src/components/{{componentPath}}.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class <%= componentName %> extends React.Component {
+  render() {
+    return <div>Edit me!</div>;
+  }
+}

--- a/init/src/index.js
+++ b/init/src/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  <%= componentName %>:
+    require("./components/<%= componentPath %>")
+};

--- a/init/test/client/main.js
+++ b/init/test/client/main.js
@@ -1,0 +1,42 @@
+/**
+ * Test setup for client-side tests.
+ *
+ * Intended for:
+ * - Karma tests: `builder run test-frontend`
+ * - Browser tests: `http://localhost:3000/test/client/test.html`
+ */
+/*globals window:false*/
+const chai = require("chai");
+const sinonChai = require("sinon-chai");
+
+// --------------------------------------------------------------------------
+// Chai / Sinon / Mocha configuration.
+// --------------------------------------------------------------------------
+// Exports
+window.expect = chai.expect;
+
+// Plugins
+chai.use(sinonChai);
+
+// Mocha (part of static include).
+window.mocha.setup({
+  ui: "bdd",
+  bail: false
+});
+
+// --------------------------------------------------------------------------
+// Bootstrap
+// --------------------------------------------------------------------------
+// Use webpack to include all app code _except_ the entry point so we can get
+// code coverage in the bundle, whether tested or not.
+const srcReq = require.context("src", true, /\.jsx?$/);
+srcReq.keys().map(srcReq);
+
+// Use webpack to infer and `require` tests automatically.
+const testsReq = require.context(".", true, /\.spec.jsx?$/);
+testsReq.keys().map(testsReq);
+
+// Only start mocha in browser.
+if (!window.__karma__) {
+  window.mocha.run();
+}

--- a/init/test/client/spec/components/{{componentPath}}.spec.jsx
+++ b/init/test/client/spec/components/{{componentPath}}.spec.jsx
@@ -1,0 +1,38 @@
+/**
+ * Client tests
+ */
+import React from "react";
+import Component from "src/components/<%= componentPath %>";
+// Use `TestUtils` to inject into DOM, simulate events, etc.
+// See: https://facebook.github.io/react/docs/test-utils.html
+import TestUtils from "react-addons-test-utils";
+
+describe("components/<%= componentPath %>", () => {
+
+  it("has expected content with deep render", () => {
+    // This is a "deep" render that renders children + all into an actual
+    // browser DOM node.
+    //
+    // https://facebook.github.io/react/docs/test-utils.html#renderintodocument
+    const rendered = TestUtils.renderIntoDocument(<Component />);
+
+    // This is a real DOM node to assert on.
+    const divNode = TestUtils
+      .findRenderedDOMComponentWithTag(rendered, "div");
+
+    expect(divNode).to.have.property("innerHTML", "Edit me!");
+  });
+
+  it("has expected content with shallow render", () => {
+    // This is a "shallow" render that renders only the current component
+    // without using the actual DOM.
+    //
+    // https://facebook.github.io/react/docs/test-utils.html#shallow-rendering
+    const renderer = TestUtils.createRenderer();
+    renderer.render(<Component />);
+    const output = renderer.getRenderOutput();
+
+    expect(output.type).to.equal("div");
+    expect(output.props.children).to.contain("Edit me");
+  });
+});

--- a/init/test/client/test.html
+++ b/init/test/client/test.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Frontend Tests</title>
+    <link rel="stylesheet" type="text/css" href="/node_modules/mocha/mocha.css">
+  </head>
+  <body>
+    <div id="mocha" />
+
+    <!-- JavaScript Test Libraries. -->
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script src="/node_modules/sinon/pkg/sinon.js"></script>
+
+    <!-- JavaScript Test Spec. -->
+    <script src="http://127.0.0.1:3001/assets/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "check-ci": "builder run lint && builder run test-ci",
     "check-cov": "builder run lint && builder run test-cov",
     "check-dev": "builder run lint && builder run test-dev",
-    "builder:lint-server": "eslint --color -c config/eslint/.eslintrc-server config/karma config/webpack",
+    "builder:lint-server": "eslint --color -c config/eslint/.eslintrc-server *.js config/karma config/webpack",
     "builder:lint": "npm run builder:lint-server",
     "builder:check": "npm run builder:lint"
   },


### PR DESCRIPTION
Parallel branch to: https://github.com/FormidableLabs/builder-init/compare/builder-init

Parallel PR to: https://github.com/FormidableLabs/builder-init/pull/7
- Moves `DEVELOPMENT.md` to archetype (instead of projects). Fixes #18
- Adds templates for all React component boilerplate files.

**Note**: This is _just_ the templates and not the prompts or a fully working `builder-init` workflow. I'm going to plan on just landing infrastructure in `master` and not releasing until `builder-init` fully works to get CI working and have digestible, reviewable chunks along the way...

/cc @coopy @chaseadamsio @exogen @boygirl @zachhale 
