### PR TITLE
Provide archetype/init.js for prompts, derived data for templates.

### DIFF
--- a/init.js
+++ b/init.js
@@ -2,9 +2,61 @@
 
 /**
  * Archetype `init` configuration.
+ *
+ * See: https://github.com/FormidableLabs/builder-init/blob/master/README.md#archetype-data
+ * for structuring this configuration file.
  */
-// TODO: REMOVE AND IMPLEMENT PROMPTS
-// https://github.com/FormidableLabs/builder-init/issues/3
-/*eslint-disable no-console*/
-console.log("TODO HERE init.js");
-/*eslint-enable no-console*/
+module.exports = {
+  // Prompts are Inquirer question objects.
+  // https://github.com/SBoudrias/Inquirer.js#question
+  //
+  // `builder-init` accepts:
+  // - an array of question objects (with a `name` property)
+  // - an object of question objects (keyed by `name`)
+  //
+  prompts: {
+    licenseDate: {
+      message: "License date",
+      default: (new Date()).getFullYear().toString()
+    },
+    licenseOrg: {
+      message: "License organization (e.g., you or your company)",
+      validate: function (val) {
+        return !!val.trim() || "Must enter a license organization";
+      }
+    },
+    // See: https://github.com/npm/validate-npm-package-name
+    packageName: {
+      message: "Package / GitHub project name (e.g., 'whiz-bang-component')",
+      validate: function (val) {
+        return /^([a-z0-9]+\-?)+$/.test(val.trim()) || "Must be lower + dash-cased string";
+      }
+    },
+    packageGitHubOrg: {
+      message: "GitHub organization name (e.g., 'AcmeCorp')",
+      validate: function (val) {
+        return /^([^\s])*$/.test(val) || "Must be GitHub-valid organization username";
+      }
+    },
+    packageDescription: {
+      message: "Package description"
+    }
+  },
+
+  // Derived fields are asynchronous functions that are given the previous user
+  // input data of the form: `function (data, cb)`. They callback with:
+  // `(err, value)`.
+  derived: {
+    componentPath: function (data, cb) { cb(null, data.packageName); },
+    componentName: function (data, cb) {
+      // PascalCase (with first character capitalized).
+      var name = data.packageName
+        .replace(/^\s+|\s+$/g, "")
+        .replace(/(^|[-_ ])+(.)/g, function (match, first, second) {
+          return second.toUpperCase();
+        });
+
+      cb(null, name);
+    }
+  }
+};

--- a/init.js
+++ b/init.js
@@ -15,16 +15,6 @@ module.exports = {
   // - an object of question objects (keyed by `name`)
   //
   prompts: {
-    licenseDate: {
-      message: "License date",
-      default: (new Date()).getFullYear().toString()
-    },
-    licenseOrg: {
-      message: "License organization (e.g., you or your company)",
-      validate: function (val) {
-        return !!val.trim() || "Must enter a license organization";
-      }
-    },
     // See: https://github.com/npm/validate-npm-package-name
     packageName: {
       message: "Package / GitHub project name (e.g., 'whiz-bang-component')",
@@ -40,6 +30,19 @@ module.exports = {
     },
     packageDescription: {
       message: "Package description"
+    },
+    licenseDate: {
+      message: "License date",
+      default: (new Date()).getFullYear().toString()
+    },
+    licenseOrg: {
+      message: "License organization (e.g., you or your company)",
+      default: function (data) {
+        return data.packageGitHubOrg;
+      },
+      validate: function (val) {
+        return !!val.trim() || "Must enter a license organization";
+      }
     }
   },
 

--- a/init/package.json
+++ b/init/package.json
@@ -1,8 +1,8 @@
 {
   "name": "<%= packageName %>",
   "version": "0.0.1",
-  "description": "<%= packageDescription %>",
-  "main": "lib/index.js",
+  "description": "<%= packageDescription || packageName %>",
+  "main": "lib/index.js",<% if (packageGitHubOrg) { %>
   "repository": {
     "type": "git",
     "url": "https://github.com/<%= packageGitHubOrg %>/<%= packageName %>.git"
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/<%= packageGitHubOrg %>/<%= packageName %>/issues"
   },
-  "homepage": "https://github.com/<%= packageGitHubOrg %>/<%= packageName %>",
+  "homepage": "https://github.com/<%= packageGitHubOrg %>/<%= packageName %>",<% } %>
   "scripts": {
     "postinstall": "builder run npm:postinstall",
     "preversion": "builder run npm:preversion",


### PR DESCRIPTION
For: https://github.com/FormidableLabs/builder-init/issues/3

Parallel 'builder-init' PR: https://github.com/FormidableLabs/builder-init/pull/10
- Add 'init.js' with user 'prompts' and 'derived' fields
- Update `package.json` to handle optional `packageGitHubOrg` field

/cc @coopy @benbayard @chaseadamsio @exogen @boygirl @zachhale
