### PR TITLE
Use archetype data in builder-init and bump builder version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ script:
   - npm --version
   - npm run builder:check
 
+  # Create global link for the archetypes for our
+  - npm link
+  - cd dev && npm link && cd ..
+
   # Initialize a fresh project from templates
   - npm install -g builder-init
   - mkdir .builder-init-tmp
@@ -45,8 +49,9 @@ script:
     "licenseOrg":"Acme",
     "destination":"whiz-bang"}'
 
-  # Run initialized project's own CI
+  # Run initialized project's own CI with npm link'ed archetypes.
   - cd whiz-bang
+  - npm link builder-react-component builder-react-component-dev
   - npm install
   - node_modules/.bin/builder run check-ci
   - npm prune --production

--- a/dev/package.json
+++ b/dev/package.json
@@ -38,6 +38,7 @@
     "phantomjs": "^1.9.18",
     "react-hot-loader": "^1.2.8",
     "sinon": "^1.16.1",
+    "webpack": "^1.12.12",
     "webpack-dev-server": "^1.10.0"
   },
   "devDependencies": {}

--- a/init/package.json
+++ b/init/package.json
@@ -19,11 +19,11 @@
     "test": "builder run npm:test"
   },
   "dependencies": {
-    "builder": "~2.2.0",
-    "builder-react-component": "^0.1.2"
+    "builder": "^2.5.0",
+    "builder-react-component": "<%= archetype.package.version ? '^' + archetype.package.version : '*' %>"
   },
   "devDependencies": {
-    "builder-react-component-dev": "^0.1.2",
+    "builder-react-component-dev": "<%= archetype.devPackage.version ? '^' + archetype.devPackage.version : '*' %>",
     "chai": "^3.2.0",
     "mocha": "^2.3.3",
     "react": "^0.14.0",


### PR DESCRIPTION
- Uses functionality in https://github.com/FormidableLabs/builder-init/pull/20 
- Switches to `npm link` for using the new archetype in CI.

/cc @chaseadamsio @benbayard @baer @coopy @zachhale
