### PR TITLE
Add json-loader and externals to support Enzyme

### DIFF
--- a/config/webpack/demo/webpack.config.dev.js
+++ b/config/webpack/demo/webpack.config.dev.js
@@ -25,7 +25,7 @@ module.exports = {
     reasons: true
   },
   resolve: {
-    extensions: ["", ".js", ".jsx"]
+    extensions: ["", ".js", ".jsx", ".json"]
   },
   module: {
     loaders: [
@@ -36,6 +36,9 @@ module.exports = {
         // we are playing around with `NODE_PATH` in builder. Manually
         // resolve path.
         loader: require.resolve("babel-loader")
+      }, {
+        test: /\.json$/,
+        loader: require.resolve("json-loader")
       }, {
         test: /\.css$/,
         loader: require.resolve("style-loader") + "!" + require.resolve("css-loader")

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -42,7 +42,7 @@ module.exports = {
     libraryTarget: "umd"
   },
   resolve: {
-    extensions: ["", ".js", ".jsx"]
+    extensions: ["", ".js", ".jsx", ".json"]
   },
   module: {
     loaders: [
@@ -53,6 +53,9 @@ module.exports = {
         // we are playing around with `NODE_PATH` in builder. Manually
         // resolve path.
         loader: require.resolve("babel-loader")
+      }, {
+        test: /\.json$/,
+        loader: require.resolve("json-loader")
       }, {
         test: /\.css$/,
         loader: require.resolve("style-loader") + "!" + require.resolve("css-loader")

--- a/config/webpack/webpack.config.test.js
+++ b/config/webpack/webpack.config.test.js
@@ -23,14 +23,12 @@ module.exports = {
   cache: true,
   context: path.join(ROOT, "test/client"),
   entry: "./main",
-  externals: prodCfg.externals.concat([
-    {
-      "cheerio": "window",
-      "react/addons": true,
-      "react/lib/ExecutionEnvironment": true,
-      "react/lib/ReactContext": true
-    }
-  ]),
+  externals: {
+    "cheerio": "window",
+    "react/addons": true,
+    "react/lib/ExecutionEnvironment": true,
+    "react/lib/ReactContext": true
+  },
   output: {
     filename: "main.js",
     publicPath: "/assets/"

--- a/config/webpack/webpack.config.test.js
+++ b/config/webpack/webpack.config.test.js
@@ -23,6 +23,14 @@ module.exports = {
   cache: true,
   context: path.join(ROOT, "test/client"),
   entry: "./main",
+  externals: prodCfg.externals.concat([
+    {
+      "cheerio": "window",
+      "react/addons": true,
+      "react/lib/ExecutionEnvironment": true,
+      "react/lib/ReactContext": true
+    }
+  ]),
   output: {
     filename: "main.js",
     publicPath: "/assets/"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "babel-loader": "^5.3.2",
     "css-loader": "^0.20.1",
     "file-loader": "^0.8.4",
+    "json-loader": "^0.5.4",
     "rimraf": "^2.4.0",
     "style-loader": "^0.12.4",
     "url-loader": "~0.5.5",


### PR DESCRIPTION
This doesn't include Enzyme itself (components can make that decision), but adds the necessary config so that Enzyme will work.

`json-loader` is also included in the demo webpack config as we have component demos that load JSON test data.

/cc @ryan-roemer @ryanisinallofus 
