### PR TITLE
Fix sanity check to support React 15

### DIFF
--- a/init/demo/index.html
+++ b/init/demo/index.html
@@ -47,8 +47,9 @@
     // Sanity-check the component loaded...
     setTimeout(function () {
       var content = document.querySelector("#content");
-      content.innerHTML = content.innerHTML ||
-        "If you can see this, something is broken (or JS is not enabled)!";
+      if (!content.innerHTML) {
+        content.innerHTML = "If you can see this, something is broken (or JS is not enabled)!";
+      }
     }, 500);
   </script>
 </body>


### PR DESCRIPTION
As discovered a while ago, the `content.innerHTML = content.innerHTML || ...` check (which potentially prints out an error message) doesn't work with React 15 due to `createElement` and no `data-reactid` (so the `innerHTML` assignment causes the DOM content to get disconnected from React).

This keeps the message, but only assigns if `innerHTML` is empty.

/cc @ryan-roemer @ryanisinallofus
